### PR TITLE
[DUBBO-ADMIN-347] Fix bug when testing no-arg method

### DIFF
--- a/dubbo-admin-ui/src/components/test/TestMethod.vue
+++ b/dubbo-admin-ui/src/components/test/TestMethod.vue
@@ -128,7 +128,11 @@
       if (method) {
         const [methodName, parametersTypes] = method.split('~')
         this.method.name = methodName
-        this.method.parameterTypes = parametersTypes.split(';')
+        if (parametersTypes) {
+          this.method.parameterTypes = parametersTypes.split(';')
+        } else { // if parametersTypes === "",  "".split(";") will produce [""], which is wrong
+          this.method.parameterTypes = []
+        }
       }
 
       let url = '/test/method?' + 'application=' + this.application +


### PR DESCRIPTION
https://github.com/apache/incubator-dubbo-admin/blob/1faaec0b747604897c4a9af6c67222744231ecd7/dubbo-admin-ui/src/components/test/TestMethod.vue#L131

resolves #347 

When testing no-arg method, the `parametersTypes` is empty, and spliting an empty string `""` generates an array of `[""]`, resulting issue #347 